### PR TITLE
new view for the house screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "funda_code_challange",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funda_code_challange",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "scripts": {
     "serve": "vue-cli-service serve",
     "start-server": "node ./server/index",

--- a/src/router.js
+++ b/src/router.js
@@ -1,15 +1,22 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import Home from './views/Home.vue'
+import House from './views/House.vue'
 
 Vue.use(Router)
 
 export default new Router({
+  mode: 'history',
   routes: [
     {
       path: '/',
       name: 'home',
       component: Home
+    },
+    {
+      path: '/house',
+      name: 'house',
+      component: House
     }
   ]
 })

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import fundaApi from './api/funda'
+import router from './router'
 
 Vue.use(Vuex)
 
@@ -33,6 +34,7 @@ export default new Vuex.Store({
         dispatch('updateDisableGetHouseButton', true)
         const houseData = await fundaApi.getHouseData(state.apiAccessKey, state.houseId)
         dispatch('updateHouseData', houseData.data)
+        router.push('House')
       } catch (e) {
         dispatch('updateHouseError', true)
         dispatch('updateDisableGetHouseButton', false)

--- a/src/views/House.vue
+++ b/src/views/House.vue
@@ -1,0 +1,9 @@
+<template>
+  <p>Hello World</p>
+</template>
+
+<script>
+  export default {
+    name: 'House'
+  }
+</script>


### PR DESCRIPTION
New view for the house screen, it is reached on a successful completion of the getHouse call


<img width="801" alt="Screen Shot 2019-05-11 at 6 30 16 PM" src="https://user-images.githubusercontent.com/676071/57572467-e74bff80-741a-11e9-8a65-81d347ffd10b.png">

