### PR TITLE
Mobile responsive layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "funda_code_challange",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funda_code_challange",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "scripts": {
     "serve": "vue-cli-service serve",
     "start-server": "node ./server/index",

--- a/src/components/MapHouseInfo.vue
+++ b/src/components/MapHouseInfo.vue
@@ -6,31 +6,34 @@
           <v-icon color="primary">$vuetify.icons.expand</v-icon>
         </template>
         <template v-slot:header>
-          <v-layout align-baseline>
-            <span class="headline pr-2">{{title}}</span>
+          <v-layout align-baseline wrap>
+            <h4 class="headline pr-2">{{title}}</h4>
             <span v-if="price" class="headline pr-2">- &euro;{{price.toLocaleString()}}</span>
             <span v-if="livingArea" class="subheading">{{livingArea}} m &sup2;</span>
           </v-layout>
         </template>
-        <v-card>
+        <v-card class="mapInfoBox-scroll">
           <v-container fluid pt-2 pb-0>
             <v-layout column align-center>
               <p class="mb-0">{{description}}</p>
               <v-btn flat small color="primary" :href="url" target="_blank">Read More</v-btn>
             </v-layout>
             <v-divider></v-divider>
-            <v-layout column mt-3>
-              <div v-for="(feature, index) in shortFeatures" :key="index" class="mb-1">
+            <v-layout column mt-2>
+              <div v-for="(feature, index) in shortFeatures" :key="index" class="mb-1 d-flex">
                 <span
                   class="body2 grey--text text--lighten-1 d-inline-block mr-2 mapInfoBox_feature_name-size ">{{feature.Naam}}:
                 </span>
-                <span class="body2 mapInfoBox_feature_value-size" v-html="feature.Waarde"></span>
-                <!-- This is usually a no-no (unescaped html) but since this data is coming from a trusted source and I cant find any non formatted versions of this information im doing it here -->
+                <span class="body2 d-inline-block mapInfoBox_feature_value-size" v-html="feature.Waarde"></span>
+                <!-- This is usually a no-no (unescaped html) but since this data is coming from a trusted source and I cant find any non-formatted versions of this information im doing it here -->
               </div>
             </v-layout>
             <v-divider></v-divider>
             <v-container pr-0 pl-0>
               <v-carousel :cycle="false" :hide-delimiters="true" height="auto">
+                <!-- There is an open bug in vuetify where an auto height will cause a scroll if the carousel is off the screen
+                     https://github.com/vuetifyjs/vuetify/issues/6206
+                 -->
                 <v-carousel-item v-for="(photo, index) in photos" :key="index" :src="photo.large"></v-carousel-item>
               </v-carousel>
             </v-container>
@@ -49,11 +52,27 @@
   }
 
   .mapInfoBox-size {
-    width: 500px;
+    max-width: 500px;
+    width: 44%;
+    max-height: calc(100% - 120px);
+    /* Keep a gutter of 20px on the bottom */
+    overflow: scroll;
   }
 
   .mapInfoBox_feature_name-size {
-    width: 30%;
+    width: 115px;
+  }
+
+  .mapInfoBox_feature_value-size {
+    width: calc(100% - 125px);
+  }
+
+  @media (max-width: 720px) {
+    .mapInfoBox-size {
+      max-width: 100%;
+      width: calc(100% - 20px);
+      /* Keep a gutter of 10px on each side left and right */
+    }
   }
 </style>
 <script>
@@ -70,7 +89,7 @@
     },
     data: function () {
       return {
-        expanded: 0
+        expanded: document.documentElement.clientWidth > 720 ? 0 : -1
       }
     }
   }

--- a/src/components/MapSearchBox.vue
+++ b/src/components/MapSearchBox.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="mapSearchBox-position mapSearchBox-size">
     <v-container pb-0 pt-2>
-      <v-form>
+      <v-form @submit="submitSearch">
         <v-text-field :label="label" v-model="searchState" append-outer-icon="search" @click:append-outer="submitSearch"
           :error="error">
         </v-text-field>
@@ -18,7 +18,16 @@
   }
 
   .mapSearchBox-size {
-    width: 500px;
+    max-width: 500px;
+    width: 44%;
+  }
+
+  @media (max-width: 720px) {
+    .mapSearchBox-size {
+      max-width: 100%;
+      width: calc(100% - 20px);
+      /* Keep a gutter of 10px on each side left and right */
+    }
   }
 </style>
 <script>
@@ -42,7 +51,10 @@
       }
     },
     methods: {
-      submitSearch: function () {
+      submitSearch: function (e) {
+        if (e) {
+          e.preventDefault()
+        }
         this.$store.dispatch(this.searchAction)
       }
     }

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -26,7 +26,7 @@
         googleMapOptions: {
           fullscreenControl: false,
           mapTypeControlOptions: {
-            position: 3 // Google Map Top right
+            position: 6 // Google Map bottom left
           }
         }
       }


### PR DESCRIPTION
Make the layout responsive

The info box is auto hidden if it would hide the map marker

On mbile the info box is full width and auto hidden
<img width="638" alt="Screen Shot 2019-05-12 at 2 28 10 PM" src="https://user-images.githubusercontent.com/676071/57582267-deaf0400-74c2-11e9-8f79-a55216db4c14.png">
<img width="663" alt="Screen Shot 2019-05-12 at 2 28 03 PM" src="https://user-images.githubusercontent.com/676071/57582268-deaf0400-74c2-11e9-9de9-3bb7716298c1.png">
<img width="832" alt="Screen Shot 2019-05-12 at 2 27 57 PM" src="https://user-images.githubusercontent.com/676071/57582270-df479a80-74c2-11e9-813c-38f83389eefd.png">
